### PR TITLE
Add dose category - Alternative

### DIFF
--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -78,8 +78,8 @@ After clicking "Next", you will access the timepoints page where you are asked t
 
     **Figure 4:** Creating a new sample collection spreadsheet - Exposure Information
 
-The last page of the creator will contain information of the chemicals used for the exposure. They are organised in three
-groups based on the dose: **BMD10** (Low), **BMD25** (Medium), **10mg/L** (High), **Alternative** (Alternative). Each chemical can only be added to one
+The last page of the creator will contain information of the chemicals used for the exposure. They are organised in different
+groups, including: **BMD10** (Low), **BMD25** (Medium), **10mg/L** (High), or **Alternative** (Alternative). Each chemical can only be added to one
 group at a time and you will need to create a new batch to test a chemical at a different dose for the same species. At
 least one group must contain a chemical for the spreadsheet to be generated but you can add as many chemicals as you want
 in each group.

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -79,7 +79,7 @@ After clicking "Next", you will access the timepoints page where you are asked t
     **Figure 4:** Creating a new sample collection spreadsheet - Exposure Information
 
 The last page of the creator will contain information of the chemicals used for the exposure. They are organised in three
-groups based on the dose: **BMD10** (Low), **BMD25** (Medium), **10mg/L** (High). Each chemical can only be added to one
+groups based on the dose: **BMD10** (Low), **BMD25** (Medium), **10mg/L** (High), **Alternative** (Alternative). Each chemical can only be added to one
 group at a time and you will need to create a new batch to test a chemical at a different dose for the same species. At
 least one group must contain a chemical for the spreadsheet to be generated but you can add as many chemicals as you want
 in each group.

--- a/ptmd/const/spreadsheets.py
+++ b/ptmd/const/spreadsheets.py
@@ -34,6 +34,7 @@ DOSE_MAPPING: dict = {
     "BMD10": "L",
     "BMD25": "M",
     "10mg/L": "H",
+    "Alternative": "A",
 }
 TIME_POINT_MAPPING: dict = {
     "TP0": "S",

--- a/ptmd/resources/api/files/create_file.yml
+++ b/ptmd/resources/api/files/create_file.yml
@@ -95,7 +95,7 @@ definitions:
         dose:
             type: string
             description: The dose for these chemicals
-            enum: ["BMD10", "BMD25", "10mg/L"]
+            enum: ["BMD10", "BMD25", "10mg/L", "Alternative"]
   Create File Response:
     type: object
     properties:

--- a/ptmd/resources/schemas/creator/create_exposure_schema.json
+++ b/ptmd/resources/schemas/creator/create_exposure_schema.json
@@ -15,6 +15,7 @@
         "BMD10",
         "BMD25",
         "10mg/L",
+        "Alternative",
         0
       ]
     }

--- a/ptmd/resources/schemas/exposure_information_sheet_schema.json
+++ b/ptmd/resources/schemas/exposure_information_sheet_schema.json
@@ -127,7 +127,7 @@
     "dose_code": {
       "type": ["string", "integer"],
       "description": "The dose code.",
-      "enum": ["0", "BMD10", "BMD25", "10mg/L", 0],
+      "enum": ["0", "BMD10", "BMD25", "10mg/L", "Alternative", 0],
       "_role": "admin"
     },
     "precisiontox_short_identifier": {


### PR DESCRIPTION
This PR fixes: https://github.com/precisiontox/ptox-metadata-manager/issues/137

* Add (not replace) a dose category named "Alternative"